### PR TITLE
:rotating_light: remove Warning "Cannot modify header information ... "

### DIFF
--- a/app/dict/index.php
+++ b/app/dict/index.php
@@ -1,4 +1,4 @@
-﻿<?PHP
+<?PHP
 require_once "../pcdl/html_head.php";
 ?>
 

--- a/app/pcdl/index.php
+++ b/app/pcdl/index.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 require_once '../pcdl/html_head.php';
 ?>
 

--- a/app/studio/index.php
+++ b/app/studio/index.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 require_once '../ucenter/login.php';
 require_once '../public/config.php';
 require_once '../public/load_lang.php';

--- a/app/wiki/index.php
+++ b/app/wiki/index.php
@@ -1,4 +1,4 @@
-﻿<?PHP
+<?PHP
 include "../pcdl/html_head.php";
 ?>
 


### PR DESCRIPTION
Warning:

![image](https://user-images.githubusercontent.com/1756956/149857965-2feda957-54c4-405e-8558-a26417eb16c1.png)

Reference:

https://stackoverflow.com/questions/8028957/how-to-fix-headers-already-sent-error-in-php

git diff:

```diff
diff --git a/app/dict/index.php b/app/dict/index.php
index 66552c49..e01e2531 100644
--- a/app/dict/index.php
+++ b/app/dict/index.php
@@ -1,4 +1,4 @@
-<U+FEFF><?PHP
+<?PHP
 require_once "../pcdl/html_head.php";
 ?>

@@ -194,4 +194,4 @@ ntf_init(1);

        <?php
 include "../pcdl/html_foot.php";
-?>
\ No newline at end of file
+?>
diff --git a/app/wiki/index.php b/app/wiki/index.php
index 6cb5263f..b82a5a38 100644
--- a/app/wiki/index.php
+++ b/app/wiki/index.php
@@ -1,4 +1,4 @@
-<U+FEFF><?PHP
+<?PHP
 include "../pcdl/html_head.php";
 ?>

@@ -239,4 +239,4 @@ include "../pcdl/html_head.php";
                });
         </script>
        </body>
-</html>
\ No newline at end of file
+</html>
```