### PR TITLE
词典侧边栏影响排版布局 #999

### DIFF
--- a/public/app/palicanon/chapter_channel.css
+++ b/public/app/palicanon/chapter_channel.css
@@ -1,5 +1,6 @@
 ul.chapter_info_list>li{
 	display:flex;
+	white-space: nowrap;
 }
 ul.chapter_info_list>li .channel_name{
 	flex:3;


### PR DESCRIPTION
临时禁止贡献者信息列表发生折行，算是暂时解决。