### PR TITLE
:bug: UpgradeSystemCommentary: 修复义注对齐时 attaJson 使用脏数据的问题

### DIFF
--- a/api-v13/app/Console/Commands/UpgradeSystemCommentary.php
+++ b/api-v13/app/Console/Commands/UpgradeSystemCommentary.php
@@ -245,16 +245,25 @@ md;
                     $this->hasData($type, 'aṭṭhakathā') &&
                     $this->hasData($type, 'ṭīkā')
                 ) {
+                    // 独立重建 attaJson，避免依赖上面 pāḷi 块是否执行
+                    $attaJsonForTika = [];
+                    foreach ($type['aṭṭhakathā'] as $keyBook => $attaParas) {
+                        foreach ($attaParas as $paraData) {
+                            $sentData = $this->getParaContent($paraData['book'], $paraData['para']);
+                            $attaJsonForTika = array_merge($attaJsonForTika, $sentData);
+                        }
+                    }
+
                     $tikaResult = [];
-                    foreach ($type['ṭīkā'] as $keyBook => $paragraphs) {
+                    foreach ($type['ṭīkā'] as $keyBook => $tikaParas) {
                         $tikaJson = [];
-                        foreach ($paragraphs as $key => $paraData) {
+                        foreach ($tikaParas as $paraData) {
                             $sentData = $this->getParaContent($paraData['book'], $paraData['para']);
                             $tikaJson = array_merge($tikaJson, $sentData);
                         }
 
                         // llm 对齐
-                        $result = $this->textAlign($attaJson, $tikaJson);
+                        $result = $this->textAlign($attaJsonForTika, $tikaJson);
                         // 将新旧数据合并 如果原来没有，就添加，有，就合并数据
                         foreach ($result as $new) {
                             $found = false;


### PR DESCRIPTION
处理义注时独立重建 attaJsonForTika，避免当段落无 pāḷi 数据时
直接引用上一段落遗留的 $attaJson，导致错误的 aṭṭhakathā 句子参与对齐。
同时消除内层循环变量 $paragraphs/$key 与外层变量的命名冲突。