### PR TITLE
chore(plugin): 版本号补到 0.4.0

### DIFF
--- a/plugins/wikipali/.claude-plugin/plugin.json
+++ b/plugins/wikipali/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "wikipali",
   "description": "WikiPali 巴利三藏平台的客户端：检索与阅读语料做研究（词形展开、全文检索、出处分布、按坐标取原文与译本），以及以 AI 模型身份写入句子。",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "visuddhinanda",
     "url": "https://github.com/visuddhinanda"


### PR DESCRIPTION
上一批改动（系统密码框登录）漏了版本 bump——脚本在前一处断言中断，
版本那行没执行到。plugin.json 的 version 决定用户能不能收到更新，
留在 0.3.0 的话 marketplace 即使标 0.4.0，用户也拿不到新版。